### PR TITLE
Fix panic on getting config value from NativeConfig

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -150,10 +150,7 @@ impl NativeClientConfig {
         }
 
         // Convert the C string to a Rust string.
-        Ok(CStr::from_bytes_with_nul(&buf)
-            .unwrap()
-            .to_string_lossy()
-            .into())
+        Ok(String::from_utf8_lossy(&buf).to_string())
     }
 }
 


### PR DESCRIPTION
Kafka can return string with multiple \0 chars (seen on Windows x64), and CStr::from_bytes_with_nul panics in that case. String::from_utf8_lossy() handles that ok